### PR TITLE
Compile in all BC localizations

### DIFF
--- a/src/codeunit/AdminToolMgt.Codeunit.al
+++ b/src/codeunit/AdminToolMgt.Codeunit.al
@@ -248,8 +248,11 @@ codeunit 50000 "Admin Tool Mgt."
     local procedure IsRecordStandardTable(TableID: Integer): Boolean
     begin
         case true of
-            //5005270 - 5005363
-            (TableID >= Database::"Delivery Reminder Header") and (TableID <= Database::"Phys. Invt. Diff. List Buffer"):
+            //5005270 - 5005363 'de' localization
+            (TableID >= 5005270) and (TableID <= 5005363):
+                exit(true);
+            //7000002 - 7000024 'es' localization
+            (TableID >= 7000002) and (TableID <= 7000024):
                 exit(true);
             //99000750 - 99008535
             (TableID >= Database::"Work Shift") and (TableID <= Database::TempBlob):


### PR DESCRIPTION
Hey Waldemar,

I tried to install your app on BC17 Spanish localization and I got this error message:

Extension compilation failed
src/codeunit/AdminToolMgt.Codeunit.al(252,35): error AL0132: 'Database' does not contain a definition for 'Delivery Reminder Header'
src/codeunit/AdminToolMgt.Codeunit.al(252,89): error AL0132: 'Database' does not contain a definition for 'Phys. Invt. Diff. List Buffer'

So I have forked your repo to find the error and after downloading symbols I found this:

![image](https://user-images.githubusercontent.com/56690443/112267935-7f9da700-8c76-11eb-90cb-86eb07ca389b.png)

I thought it can't compile because the localization. In my database I don't have objects in the 5005270 - 5005363 range (Deutsch objects?). Instead I have in the 7000002 - 7000024 range (Spanish objects).

Changing tablenames to numbers make it work. I know this is not the cleanest solution in the world but this way this app could be growing to allow more localizations.
![image](https://user-images.githubusercontent.com/56690443/112281297-2dfd1880-8c86-11eb-8557-c6d3de6acba3.png)

Here you have a pull request with these changes. Use it if you want to.

PD: Great work with this toolbox!!